### PR TITLE
tabline: add support for tab_nr_type as string

### DIFF
--- a/autoload/airline/extensions/tabline.vim
+++ b/autoload/airline/extensions/tabline.vim
@@ -251,7 +251,9 @@ function! s:get_tabs()
     endif
     let val = '%('
     if s:show_tab_nr
-      if s:tab_nr_type == 0
+      if type(s:tab_nr_type) == type('')
+        let val .= substitute(s:tab_nr_type, '__tabnr__', i, 'g')
+      elseif s:tab_nr_type == 0
         let val .= ' %{len(tabpagebuflist('.i.'))}'
       else
         let val .= (g:airline_symbols.space).i

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -375,11 +375,13 @@ eclim <https://eclim.org>
 * configure filename match rules to exclude from the tabline. >
   let g:airline#extensions#tabline#excludes = []
 <
-* configure how numbers are calculated in tab mode. >
+* configure how numbers are displayed in tab mode. >
   let g:airline#extensions#tabline#tab_nr_type = 0 " # of splits (default)
   let g:airline#extensions#tabline#tab_nr_type = 1 " tab number
+  let g:airline#extensions#tabline#tab_nr_type = '__tabnr__' " string where __tabnr__ is replaced
+  let g:airline#extensions#tabline#tab_nr_type = '[__tabnr__.%{len(tabpagebuflist(__tabnr__))}]'
 <
-* enable/disable displaying tab number in tabs mode. >
+* enable/disable display of number/string in tabs mode. >
   let g:airline#extensions#tabline#show_tab_nr = 1
 
 * defines the name of a formatter for how buffer names are displayed. >


### PR DESCRIPTION
'__tabnr__' gets replaced with the tab number. This allows for custom
configurations, where you want to have both the tab number and the
number of windows at the same time, e.g.:

    let g:airline#extensions#tabline#tab_nr_type = '[__tabnr__.%{len(tabpagebuflist(__tabnr__))}]'