### PR TITLE
This fixes the extra space at the end of hunks section

### DIFF
--- a/autoload/airline/extensions/hunks.vim
+++ b/autoload/airline/extensions/hunks.vim
@@ -58,7 +58,7 @@ function! airline#extensions#hunks#get_hunks()
       endif
     endfor
   endif
-  return string
+  return strpart(string, 0, strlen(string)-1)
 endfunction
 
 function! airline#extensions#hunks#init(ext)


### PR DESCRIPTION
It simply removes the space that was being placed at the end of the section. This works whether `non_zero_only` is used or not.