### PR TITLE
Hides tabline type as the doc says

### DIFF
--- a/autoload/airline/extensions/tabline.vim
+++ b/autoload/airline/extensions/tabline.vim
@@ -258,7 +258,9 @@ function! s:get_buffers()
   call b.add_section('airline_tabfill', '')
   call b.split()
   call b.add_section('airline_tabfill', '')
-  call b.add_section('airline_tabtype', ' buffers ')
+  if s:show_tab_type
+    call b.add_section('airline_tabtype', ' tabs ')
+  endif
 
   let s:current_bufnr = cur
   let s:current_tabline = b.build()


### PR DESCRIPTION
From the documentation:
```
* enable/disable displaying tab type (far right)
  let g:airline#extensions#tabline#show_tab_type = 1
```
Which suggests to me that it only makes sense to hide the tab type for both buffer and tab types. This PR fixes that.

@bling thanks for the amazing plugin.