### PR TITLE
Replace column number with virtual column number

### DIFF
--- a/autoload/airline/init.vim
+++ b/autoload/airline/init.vim
@@ -105,7 +105,7 @@ function! airline#init#sections()
     let g:airline_section_y = airline#section#create_right(['ffenc'])
   endif
   if !exists('g:airline_section_z')
-    let g:airline_section_z = airline#section#create(['windowswap', '%3p%%'.spc, 'linenr', ':%3c '])
+    let g:airline_section_z = airline#section#create(['windowswap', '%3p%%'.spc, 'linenr', ':%3v '])
   endif
   if !exists('g:airline_section_warning')
     let g:airline_section_warning = airline#section#create(['syntastic', 'eclim', 'whitespace'])

--- a/t/init.vim
+++ b/t/init.vim
@@ -44,7 +44,7 @@ describe 'init sections'
   it 'section z should be line numbers'
     Expect g:airline_section_z =~ '%3p%%'
     Expect g:airline_section_z =~ '%4l'
-    Expect g:airline_section_z =~ '%3c'
+    Expect g:airline_section_z =~ '%3v'
   end
 
   it 'should not redefine sections already defined'


### PR DESCRIPTION
I think the column number should indicate the position of the column of the cursor that human sees but not the number of the characters between the cursor and the start of the line by default.
If one uses tab for indentation, column number is important for tipping if the line is longer than the limitation of code conventions.

Refer to #305.