### PR TITLE
selectively disable airline for selected windows

### DIFF
--- a/autoload/airline.vim
+++ b/autoload/airline.vim
@@ -89,6 +89,10 @@ endfunction
 
 function! airline#update_statusline()
   for nr in filter(range(1, winnr('$')), 'v:val != winnr()')
+    if !empty(getwinvar(nr, 'airline_disabled')) &&
+        \ getwinvar(nr, 'airline_disabled')
+        continue
+    endif
     call setwinvar(nr, 'airline_active', 0)
     let context = { 'winnr': nr, 'active': 0, 'bufnr': winbufnr(nr) }
     call s:invoke_funcrefs(context, s:inactive_funcrefs)

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -126,6 +126,11 @@ values):
   heavily) >
   let g:airline_exclude_preview = 0
 <
+* disable the Airline customization for selective windows (this is a
+  window-local variable so you can disable it for only some windows) >
+  let w:airline_disabled = 1
+<
+
 ==============================================================================
 COMMANDS                                                  *airline-commands*
 


### PR DESCRIPTION
This will allow to disable airline for certain windows. I like to have this for the csv plugin, so that the HEader command looks nicely and no statusline is interfering.