### PR TITLE
tabline#default#format: keep dirname for __init__.py

### DIFF
--- a/autoload/airline/extensions/tabline/default.vim
+++ b/autoload/airline/extensions/tabline/default.vim
@@ -15,7 +15,9 @@ function! airline#extensions#tabline#default#format(bufnr, buffers)
     let _ .= '[No Name]'
   else
     if s:fnamecollapse
-      let _ .= substitute(fnamemodify(name, s:fmod), '\v\w\zs.{-}\ze(\\|/)', '', 'g')
+      " Collapse directories, but not for the last one if this is a
+      " __init__.py file.
+      let _ .= substitute(fnamemodify(name, s:fmod), '\v\w\zs.{-}\ze(\\|/)(__init__.py)@!', '', 'g')
     else
       let _ .= fnamemodify(name, s:fmod)
     endif


### PR DESCRIPTION
This could be made a setting, assuming that there are similar cases
where the filename itself is not descriptive.