### PR TITLE
Fix get_buffer_list being called always via get()

### DIFF
--- a/autoload/airline/extensions/tabline.vim
+++ b/autoload/airline/extensions/tabline.vim
@@ -130,7 +130,10 @@ function! airline#extensions#tabline#title(n)
 endfunction
 
 function! airline#extensions#tabline#get_buffer_name(nr)
-  return airline#extensions#tabline#{s:formatter}#format(a:nr, get(s:, 'current_buffer_list', s:get_buffer_list()))
+  let buffer_list = exists('s:current_buffer_list')
+        \ ? s:current_buffer_list
+        \ : s:get_buffer_list()
+  return airline#extensions#tabline#{s:formatter}#format(a:nr, buffer_list)
 endfunction
 
 function! s:get_buffer_list()


### PR DESCRIPTION
Vim's `get()` calls the expression for `{default}` always, not only if
the default is going to be used!

This caused `airline#extensions#tabline#get_buffer_name` to not use the
cached value.

Fixes https://github.com/bling/vim-airline/issues/697.