### PR TITLE
Fix get_buffer_list cache regression

### DIFF
--- a/autoload/airline/extensions/tabline.vim
+++ b/autoload/airline/extensions/tabline.vim
@@ -59,19 +59,22 @@ function! s:toggle_on()
   let [ s:original_tabline, s:original_showtabline ] = [ &tabline, &showtabline ]
 
   set tabline=%!airline#extensions#tabline#get()
-  if s:buf_min_count <= 0 && s:tab_min_count <= 1
-    set showtabline=2
-  else
-    augroup airline_tabline
-      autocmd!
+  augroup airline_tabline
+    autocmd!
+    " Invalidate cache.
+    autocmd BufAdd,BufUnload * unlet! s:current_buffer_list
+
+    if s:buf_min_count <= 0 && s:tab_min_count <= 1
+      set showtabline=2
+    else
       if s:show_buffers == 1
         autocmd BufEnter * call <sid>show_tabline(s:buf_min_count, len(s:get_buffer_list()))
         autocmd BufUnload * call <sid>show_tabline(s:buf_min_count, len(s:get_buffer_list()) - 1)
       else
         autocmd TabEnter * call <sid>show_tabline(s:tab_min_count, tabpagenr('$'))
       endif
-    augroup END
-  endif
+    endif
+  augroup END
 endfunction
 
 function! airline#extensions#tabline#load_theme(palette)
@@ -130,13 +133,14 @@ function! airline#extensions#tabline#title(n)
 endfunction
 
 function! airline#extensions#tabline#get_buffer_name(nr)
-  let buffer_list = exists('s:current_buffer_list')
-        \ ? s:current_buffer_list
-        \ : s:get_buffer_list()
-  return airline#extensions#tabline#{s:formatter}#format(a:nr, buffer_list)
+  return airline#extensions#tabline#{s:formatter}#format(a:nr, s:get_buffer_list())
 endfunction
 
 function! s:get_buffer_list()
+  if exists('s:current_buffer_list')
+    return s:current_buffer_list
+  endif
+
   let buffers = []
   let cur = bufnr('%')
   for nr in range(1, bufnr('$'))


### PR DESCRIPTION
Use `s:current_buffer_list` always in `s:get_buffer_list()`, and
invalidate it via BufAdd and BufUnload.

Fixes regression from https://github.com/bling/vim-airline/commit/ce58af719109f83f965b1d8b87232b8161fcfe90#commitcomment-9647487.