### PR TITLE
Base16 color fixes to resemble gui

### DIFF
--- a/autoload/airline/themes/base16.vim
+++ b/autoload/airline/themes/base16.vim
@@ -44,7 +44,6 @@ if get(g:, 'airline#themes#base16#constant', 0)
   " Replace mode
   let g:airline#themes#base16#palette.replace = {
         \ 'airline_a': [s:gui_dark_gray, s:gui_red, s:cterm_dark_gray, s:cterm_red, ''],
-
         \ 'airline_c': [s:gui_red, s:gui_med_gray_hi, s:cterm_red, s:cterm_med_gray_hi, ''],
         \ }
   let g:airline#themes#base16#palette.replace_modified = copy(g:airline#themes#base16#palette.insert_modified)

--- a/autoload/airline/themes/base16.vim
+++ b/autoload/airline/themes/base16.vim
@@ -44,6 +44,7 @@ if get(g:, 'airline#themes#base16#constant', 0)
   " Replace mode
   let g:airline#themes#base16#palette.replace = {
         \ 'airline_a': [s:gui_dark_gray, s:gui_red, s:cterm_dark_gray, s:cterm_red, ''],
+
         \ 'airline_c': [s:gui_red, s:gui_med_gray_hi, s:cterm_red, s:cterm_med_gray_hi, ''],
         \ }
   let g:airline#themes#base16#palette.replace_modified = copy(g:airline#themes#base16#palette.insert_modified)
@@ -69,7 +70,7 @@ else
           \ }
 
     let s:N1 = airline#themes#get_highlight2(['DiffText', 'bg'], ['DiffText', 'fg'], 'bold')
-    let s:N2 = airline#themes#get_highlight('Visual')
+    let s:N2 = airline#themes#get_highlight2(['Visual', 'fg'], ['Visual', 'bg'])
     let s:N3 = airline#themes#get_highlight('CursorLine')
     let g:airline#themes#base16#palette.normal = airline#themes#generate_color_map(s:N1, s:N2, s:N3)
 
@@ -78,19 +79,19 @@ else
           \ 'statusline': [ group[0], '', group[2], '', '' ]
           \ }
 
-    let s:I1 = airline#themes#get_highlight2(['DiffAdded', 'bg'], ['DiffAdded', 'fg'], 'bold')
+    let s:I1 = airline#themes#get_highlight2(['DiffText', 'bg'], ['DiffAdded', 'fg'], 'bold')
     let s:I2 = airline#themes#get_highlight2(['DiffAdded', 'fg'], ['Normal', 'bg'])
     let s:I3 = s:N3
     let g:airline#themes#base16#palette.insert = airline#themes#generate_color_map(s:I1, s:I2, s:I3)
     let g:airline#themes#base16#palette.insert_modified = g:airline#themes#base16#palette.normal_modified
 
-    let s:R1 = airline#themes#get_highlight2(['WarningMsg', 'bg'], ['WarningMsg', 'fg'], 'bold')
+    let s:R1 = airline#themes#get_highlight2(['DiffText', 'bg'], ['WarningMsg', 'fg'], 'bold')
     let s:R2 = s:N2
     let s:R3 = s:N3
     let g:airline#themes#base16#palette.replace = airline#themes#generate_color_map(s:R1, s:R2, s:R3)
     let g:airline#themes#base16#palette.replace_modified = g:airline#themes#base16#palette.normal_modified
 
-    let s:V1 = airline#themes#get_highlight2(['Normal', 'bg'], ['Constant', 'fg'], 'bold')
+    let s:V1 = airline#themes#get_highlight2(['DiffText', 'bg'], ['Constant', 'fg'], 'bold')
     let s:V2 = airline#themes#get_highlight2(['Constant', 'fg'], ['Normal', 'bg'])
     let s:V3 = s:N3
     let g:airline#themes#base16#palette.visual = airline#themes#generate_color_map(s:V1, s:V2, s:V3)


### PR DESCRIPTION
In terminal, Modeline picks up wrong color for displaying texts; with this patch the texts are readable, resembling how it looks on the GUI

Before:
![terminal - no name - vim_034](https://cloud.githubusercontent.com/assets/6640417/6197200/f3695536-b3e1-11e4-8afb-d954ce44bf21.png)
![terminal - no name - vim_035](https://cloud.githubusercontent.com/assets/6640417/6197202/f5cbacca-b3e1-11e4-8b01-30393d3bdf55.png)
After:
![terminal - no name - vim_036](https://cloud.githubusercontent.com/assets/6640417/6197205/fb85ed1a-b3e1-11e4-9266-30499f0ebb0a.png)
![terminal - no name - vim_037](https://cloud.githubusercontent.com/assets/6640417/6197207/fdf71f56-b3e1-11e4-895b-c10c6e4d0379.png)
