### PR TITLE
Add support for 24-bit colors with +termtruecolor flag

### DIFF
--- a/autoload/airline/builder.vim
+++ b/autoload/airline/builder.vim
@@ -77,7 +77,7 @@ function! s:should_change_group(group1, group2)
   endif
   let color1 = airline#highlighter#get_highlight(a:group1)
   let color2 = airline#highlighter#get_highlight(a:group2)
-  if has('gui_running')
+  if has('gui_running') || (has("termtruecolor") && &guicolors == 1)
     return color1[1] != color2[1] || color1[0] != color2[0]
   else
     return color1[3] != color2[3] || color1[2] != color2[2]

--- a/autoload/airline/highlighter.vim
+++ b/autoload/airline/highlighter.vim
@@ -16,13 +16,13 @@ endfunction
 
 function! s:get_syn(group, what)
   " need to pass in mode, known to break on 7.3.547
-  let mode = has('gui_running') ? 'gui' : 'cterm'
+  let mode = has('gui_running') || (has("termtruecolor") && &guicolors == 1) ? 'gui' : 'cterm'
   let color = synIDattr(synIDtrans(hlID(a:group)), a:what, mode)
   if empty(color) || color == -1
     let color = synIDattr(synIDtrans(hlID('Normal')), a:what, mode)
   endif
   if empty(color) || color == -1
-    if has('gui_running')
+    if has('gui_running') || (has("termtruecolor") && &guicolors == 1)
       let color = a:what ==# 'fg' ? '#000000' : '#FFFFFF'
     else
       let color = a:what ==# 'fg' ? 0 : 1
@@ -34,7 +34,7 @@ endfunction
 function! s:get_array(fg, bg, opts)
   let fg = a:fg
   let bg = a:bg
-  return has('gui_running')
+  return has('gui_running') || (has("termtruecolor") && &guicolors == 1)
         \ ? [ fg, bg, '', '', join(a:opts, ',') ]
         \ : [ '', '', fg, bg, join(a:opts, ',') ]
 endfunction
@@ -42,7 +42,7 @@ endfunction
 function! airline#highlighter#get_highlight(group, ...)
   let fg = s:get_syn(a:group, 'fg')
   let bg = s:get_syn(a:group, 'bg')
-  let reverse = has('gui_running')
+  let reverse = has('gui_running') || (has("termtruecolor") && &guicolors == 1)
         \ ? synIDattr(synIDtrans(hlID(a:group)), 'reverse', 'gui')
         \ : synIDattr(synIDtrans(hlID(a:group)), 'reverse', 'cterm')
         \|| synIDattr(synIDtrans(hlID(a:group)), 'reverse', 'term')


### PR DESCRIPTION
Enables 24-bit truecolor support in terminal vim. Requires patched vim from [ZyX](https://bitbucket.org/ZyX_I/vim) ([patch here](https://groups.google.com/forum/#!topic/vim_dev/ed0GTyYrSYg)) and supporting terminal.

Requires the following in vimrc:
```viml
if has('termtruecolor')
  let &t_8f="\033[38;2;%ld;%ld;%ldm"
  let &t_8b="\033[48;2;%ld;%ld;%ldm"
  set guicolors
endif
```
More information about 24-bit truecolor support in terminal environments can be found [here](https://gist.github.com/XVilka/8346728)