### PR TITLE
badwolf theme: make inactive status line stand out more

### DIFF
--- a/autoload/airline/themes/badwolf.vim
+++ b/autoload/airline/themes/badwolf.vim
@@ -15,7 +15,7 @@ let s:V4 = [ '#c7915b' , 173 ]                   " coffee
 let s:PA = [ '#f4cf86' , 222 ]                   " dirtyblonde
 let s:RE = [ '#ff9eb8' , 211 ]                   " dress
 
-let s:IA = [ s:N2[1] , s:N3[1] , s:N2[3] , s:N3[3] , '' ]
+let s:IA = [ s:N3[1] , s:N2[1] , s:N3[3] , s:N3[3] , '' ]
 
 let g:airline#themes#badwolf#palette = {}
 

--- a/autoload/airline/themes/badwolf.vim
+++ b/autoload/airline/themes/badwolf.vim
@@ -15,7 +15,7 @@ let s:V4 = [ '#c7915b' , 173 ]                   " coffee
 let s:PA = [ '#f4cf86' , 222 ]                   " dirtyblonde
 let s:RE = [ '#ff9eb8' , 211 ]                   " dress
 
-let s:IA = [ s:N3[1] , s:N2[1] , s:N3[3] , s:N3[3] , '' ]
+let s:IA = [ s:N3[1] , s:N2[1] , s:N3[3] , s:N2[3] , '' ]
 
 let g:airline#themes#badwolf#palette = {}
 


### PR DESCRIPTION
When using horizontal splits with the badwolf theme, the statuslines of inactive windows are hard to see. To improve the window boundry's visibility, I inverted the fg and bg colours.