### PR TITLE
Dectect when vim.exe is running on ConEmu with 256 colors configured

### DIFF
--- a/autoload/airline/highlighter.vim
+++ b/autoload/airline/highlighter.vim
@@ -1,7 +1,8 @@
 " MIT License. Copyright (c) 2013-2015 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
-let s:is_win32term = (has('win32') || has('win64')) && !has('gui_running')
+let s:is_win32term = (has('win32') || has('win64')) && !has('gui_running') && (empty($CONEMUBUILD) || &term !=? 'xterm')
+
 let s:separators = {}
 let s:accents = {}
 


### PR DESCRIPTION
If vim.exe is running inside ConEmu, and it has been configured to support 256 colors, airline will be able to use full colors scheme, hence not consider it is win32term.

For more information on ConEmu 256 color configuration and vim.exe, see http://stackoverflow.com/questions/14315519/conemu-vim-syntax-highlight