### PR TITLE
tabline: add fnametruncate option to truncate long tab/buffer names

### DIFF
--- a/autoload/airline/extensions/tabline/formatters/default.vim
+++ b/autoload/airline/extensions/tabline/formatters/default.vim
@@ -3,6 +3,7 @@
 
 let s:fmod = get(g:, 'airline#extensions#tabline#fnamemod', ':~:.')
 let s:fnamecollapse = get(g:, 'airline#extensions#tabline#fnamecollapse', 1)
+let s:fnametruncate = get(g:, 'airline#extensions#tabline#fnametruncate', 0)
 let s:buf_nr_format = get(g:, 'airline#extensions#tabline#buffer_nr_format', '%s: ')
 let s:buf_nr_show = get(g:, 'airline#extensions#tabline#buffer_nr_show', 0)
 let s:buf_modified_symbol = g:airline_symbols.modified
@@ -18,6 +19,9 @@ function! airline#extensions#tabline#formatters#default#format(bufnr, buffers)
       let _ .= substitute(fnamemodify(name, s:fmod), '\v\w\zs.{-}\ze(\\|/)', '', 'g')
     else
       let _ .= fnamemodify(name, s:fmod)
+    endif
+    if a:bufnr != bufnr('%') && s:fnametruncate && strlen(_) > s:fnametruncate
+      let _ = strpart(_, 0, s:fnametruncate)
     endif
   endif
 

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -489,6 +489,9 @@ exposed.
 <
     * configure collapsing parent directories in buffer name. >
       let g:airline#extensions#tabline#fnamecollapse = 1
+<
+    * configure truncating non-active buffer names to specified length. >
+      let g:airline#extensions#tabline#fnametruncate = 0
 
   " The `unique_tail` algorithm will display the tail of the filename, unless
   " there is another file of the same name, in which it will display it along


### PR DESCRIPTION
This helps fit more tabs/buffers in the tabline.  Please review, thanks.