### PR TITLE
Make horizontal split more obvious in case CursorLine is cleared

### DIFF
--- a/autoload/airline/themes/tomorrow.vim
+++ b/autoload/airline/themes/tomorrow.vim
@@ -7,7 +7,7 @@ function! airline#themes#tomorrow#refresh()
 
   let s:N1 = airline#themes#get_highlight2(['Normal', 'bg'], ['Directory', 'fg'], 'bold')
   let s:N2 = airline#themes#get_highlight('Pmenu')
-  let s:N3 = airline#themes#get_highlight('CursorLine')
+  let s:N3 = [ '#ffffff' , '#282a2e' , 255     , 'black' ]
   let g:airline#themes#tomorrow#palette.normal = airline#themes#generate_color_map(s:N1, s:N2, s:N3)
 
   let group = airline#themes#get_highlight('vimCommand')

--- a/autoload/airline/themes/tomorrow.vim
+++ b/autoload/airline/themes/tomorrow.vim
@@ -33,7 +33,7 @@ function! airline#themes#tomorrow#refresh()
   let g:airline#themes#tomorrow#palette.visual = airline#themes#generate_color_map(s:V1, s:V2, s:V3)
   let g:airline#themes#tomorrow#palette.visual_modified = g:airline#themes#tomorrow#palette.normal_modified
 
-  let s:IA = [ '#4e4e4e' , '#2A2A2A' , 239 , 235 , '' ]
+  let s:IA = airline#themes#get_highlight('StatusLineNC')
   let g:airline#themes#tomorrow#palette.inactive = airline#themes#generate_color_map(s:IA, s:IA, s:IA)
   let g:airline#themes#tomorrow#palette.inactive_modified = {
         \ 'airline_c': [ group[0], '', group[2], '', '' ]

--- a/autoload/airline/themes/tomorrow.vim
+++ b/autoload/airline/themes/tomorrow.vim
@@ -33,7 +33,7 @@ function! airline#themes#tomorrow#refresh()
   let g:airline#themes#tomorrow#palette.visual = airline#themes#generate_color_map(s:V1, s:V2, s:V3)
   let g:airline#themes#tomorrow#palette.visual_modified = g:airline#themes#tomorrow#palette.normal_modified
 
-  let s:IA = airline#themes#get_highlight2(['NonText', 'fg'], ['CursorLine', 'bg'])
+  let s:IA = [ '#4e4e4e' , '#2A2A2A' , 239 , 235 , '' ]
   let g:airline#themes#tomorrow#palette.inactive = airline#themes#generate_color_map(s:IA, s:IA, s:IA)
   let g:airline#themes#tomorrow#palette.inactive_modified = {
         \ 'airline_c': [ group[0], '', group[2], '', '' ]


### PR DESCRIPTION
If line number highlighting is enabled but line highlighting is off,
the background color of inactive status bar is set to the background
color

There is probably a better way to achieve this, suggestions welcome