### PR TITLE
Added support for Neovim's terminal buffer mode

### DIFF
--- a/autoload/airline.vim
+++ b/autoload/airline.vim
@@ -142,6 +142,8 @@ function! airline#check_mode(winnr)
       let l:mode = ['replace']
     elseif l:m =~# '\v(v|V||s|S|)'
       let l:mode = ['visual']
+    elseif l:m ==# "t"
+      let l:mode = ['terminal']
     else
       let l:mode = ['normal']
     endif

--- a/autoload/airline/init.vim
+++ b/autoload/airline/init.vim
@@ -41,6 +41,7 @@ function! airline#init#bootstrap()
         \ 's'  : 'SELECT',
         \ 'S'  : 'S-LINE',
         \ '' : 'S-BLOCK',
+        \ 't'  : 'TERMINAL',
         \ }, 'keep')
 
   call s:check_defined('g:airline_theme_map', {})


### PR DESCRIPTION
Neovim has a `:term[inal]` command, which allows you to create a buffer with a terminal emulator. This buffer has a new supported mode `t` for interacting directly with the terminal. This pull request adds support for this new mode. I hope this covers everything necessary; it seems to pass the tests and works as expected locally, though I could easily have missed some vital changes.