### PR TITLE
Remove trailing slashes in unique_tail formatter

### DIFF
--- a/autoload/airline/extensions/tabline/formatters/unique_tail.vim
+++ b/autoload/airline/extensions/tabline/formatters/unique_tail.vim
@@ -10,7 +10,7 @@ function! airline#extensions#tabline#formatters#unique_tail#format(bufnr, buffer
     if empty(name)
       let map[nr] = '[No Name]'
     else
-      let tail = fnamemodify(name, ':t')
+      let tail = fnamemodify(name, ':s?/\+$??:t')
       if has_key(tails, tail)
         let duplicates[nr] = nr
       endif


### PR DESCRIPTION
Using the `unique_tail` formatter I sometimes get this error when `:edit`ing a directory:

```
Error detected while processing function airline#extensions#tabline#get..airline#extensions#tabline#buffers#get.
.<SNR>136_get_visible_buffers..airline#extensions#tabline#get_buffer_name..airline#extensions#tabline#formatters
#unique_tail#format:                                                                                            
line   13:                                                                                                      
E713: Cannot use empty key for Dictionary
```

Turns out it only happens when I specify the directory with a trailing slash, which causes the `fnamemodify` call to return an empty string.