### PR TITLE
Fixed tomorrow theme when overriding highlight Normal

### DIFF
--- a/autoload/airline/themes/tomorrow.vim
+++ b/autoload/airline/themes/tomorrow.vim
@@ -5,7 +5,7 @@ function! airline#themes#tomorrow#refresh()
         \ 'red': airline#themes#get_highlight('Constant'),
         \ }
 
-  let s:N1 = airline#themes#get_highlight2(['Normal', 'bg'], ['Directory', 'fg'], 'bold')
+  let s:N1 = airline#themes#get_highlight2(['TabLine', 'bg'], ['Directory', 'fg'], 'bold')
   let s:N2 = airline#themes#get_highlight('Pmenu')
   let s:N3 = airline#themes#get_highlight('CursorLine')
   let g:airline#themes#tomorrow#palette.normal = airline#themes#generate_color_map(s:N1, s:N2, s:N3)
@@ -15,8 +15,8 @@ function! airline#themes#tomorrow#refresh()
         \ 'airline_c': [ group[0], '', group[2], '', '' ]
         \ }
 
-  let s:I1 = airline#themes#get_highlight2(['Normal', 'bg'], ['MoreMsg', 'fg'], 'bold')
-  let s:I2 = airline#themes#get_highlight2(['MoreMsg', 'fg'], ['Normal', 'bg'])
+  let s:I1 = airline#themes#get_highlight2(['TabLine', 'bg'], ['MoreMsg', 'fg'], 'bold')
+  let s:I2 = airline#themes#get_highlight2(['MoreMsg', 'fg'], ['TabLine', 'bg'])
   let s:I3 = s:N3
   let g:airline#themes#tomorrow#palette.insert = airline#themes#generate_color_map(s:I1, s:I2, s:I3)
   let g:airline#themes#tomorrow#palette.insert_modified = g:airline#themes#tomorrow#palette.normal_modified
@@ -27,8 +27,8 @@ function! airline#themes#tomorrow#refresh()
   let g:airline#themes#tomorrow#palette.replace = airline#themes#generate_color_map(s:R1, s:R2, s:R3)
   let g:airline#themes#tomorrow#palette.replace_modified = g:airline#themes#tomorrow#palette.normal_modified
 
-  let s:V1 = airline#themes#get_highlight2(['Normal', 'bg'], ['Constant', 'fg'], 'bold')
-  let s:V2 = airline#themes#get_highlight2(['Constant', 'fg'], ['Normal', 'bg'])
+  let s:V1 = airline#themes#get_highlight2(['TabLine', 'bg'], ['Constant', 'fg'], 'bold')
+  let s:V2 = airline#themes#get_highlight2(['Constant', 'fg'], ['TabLine', 'bg'])
   let s:V3 = s:N3
   let g:airline#themes#tomorrow#palette.visual = airline#themes#generate_color_map(s:V1, s:V2, s:V3)
   let g:airline#themes#tomorrow#palette.visual_modified = g:airline#themes#tomorrow#palette.normal_modified


### PR DESCRIPTION
In order to get vim to play nice on a terminal with transparent background, I've set the following options in my vimrc file:
```
highlight Normal ctermbg=none
highlight NonText ctermbg=none
```
Adding these lines have the unfortunate effect of messing up the airline colors for the tomorrow theme. The text colours appear pink in Normal mode, with pinkish highlights in Insert and Visual mode.

![bug](https://cloud.githubusercontent.com/assets/571891/7991356/24527aa2-0b2a-11e5-9085-a19e6e524e85.png)

It seems like the problem is that the airline tomorrow theme is using the `highlight Normal` background color as part of the themes. An possible fix for the this theme would be to use the `highlight TabLine` background color instead, which is defined to be the same as the default `highlight Normal` background color. 