### PR TITLE
Add checks for existing key to make #786 work in neovim

### DIFF
--- a/autoload/airline.vim
+++ b/autoload/airline.vim
@@ -161,7 +161,7 @@ function! airline#check_mode(winnr)
     call add(l:mode, 'paste')
   endif
 
-  if g:airline_detect_crypt && !empty(&key)
+  if g:airline_detect_crypt && exists("+key") && !empty(&key)
     call add(l:mode, 'crypt')
   endif
 

--- a/autoload/airline/parts.vim
+++ b/autoload/airline/parts.vim
@@ -55,7 +55,7 @@ function! airline#parts#mode()
 endfunction
 
 function! airline#parts#crypt()
-  return g:airline_detect_crypt && !empty(&key) ? g:airline_symbols.crypt : ''
+  return g:airline_detect_crypt && exists("+key") && !empty(&key) ? g:airline_symbols.crypt : ''
 endfunction
 
 function! airline#parts#paste()


### PR DESCRIPTION
This fixes a bug which lets neovim throw errors on startup introduced by https://github.com/bling/vim-airline/pull/786