### PR TITLE
Allow padding to be dynamic

### DIFF
--- a/autoload/airline/extensions/default.vim
+++ b/autoload/airline/extensions/default.vim
@@ -18,7 +18,7 @@ function! s:get_section(winnr, key, ...)
       return ''
     endif
   endif
-  let spc = g:airline_symbols.space
+  let spc = g:airline_symbols.pad_section
   let text = airline#util#getwinvar(a:winnr, 'airline_section_'.a:key, g:airline_section_{a:key})
   let [prefix, suffix] = [get(a:000, 0, '%('.spc), get(a:000, 1, spc.'%)')]
   return empty(text) ? '' : prefix.text.suffix

--- a/autoload/airline/init.vim
+++ b/autoload/airline/init.vim
@@ -64,6 +64,9 @@ function! airline#init#bootstrap()
         \ 'modified': '+',
         \ 'space': ' ',
         \ 'crypt': get(g:, 'airline_crypt_symbol', nr2char(0x1F512)),
+        \ 'pad': get(g:airline_symbols, 'space', ' '),
+        \ 'pad_section': get(g:airline_symbols, 'space', ' '),
+        \ 'pad_sep': get(g:airline_symbols, 'space', ' '),
         \ }, 'keep')
 
   call airline#parts#define('mode', {

--- a/autoload/airline/parts.vim
+++ b/autoload/airline/parts.vim
@@ -81,3 +81,12 @@ function! airline#parts#ffenc()
   return printf('%s%s', &fenc, strlen(&ff) > 0 ? '['.&ff.']' : '')
 endfunction
 
+function! airline#parts#sep_left()
+  let l:pad = g:airline_symbols.pad_sep
+  return l:pad . g:airline_left_alt_sep . l:pad
+endfunction
+
+function! airline#parts#sep_right()
+  let l:pad = g:airline_symbols.pad_sep
+  return l:pad . g:airline_right_alt_sep . l:pad
+endfunction

--- a/autoload/airline/section.vim
+++ b/autoload/airline/section.vim
@@ -2,7 +2,6 @@
 " vim: et ts=2 sts=2 sw=2
 
 call airline#init#bootstrap()
-let s:spc = g:airline_symbols.space
 
 function! s:wrap_accent(part, value)
   if exists('a:part.accent')
@@ -24,10 +23,10 @@ function! s:create(parts, append)
       let func = '"'.(part.text).'"'
     else
       if a:append > 0 && idx != 0
-        let val .= s:spc.g:airline_left_alt_sep.s:spc
+        let val .= '%{airline#parts#sep_left()}'
       endif
       if a:append < 0 && idx != 0
-        let val = s:spc.g:airline_right_alt_sep.s:spc.val
+        let val = '%{airline#parts#sep_right()}'.val
       endif
       if exists('part.raw')
         let _ .= s:wrap_accent(part, val.(part.raw))

--- a/autoload/airline/util.vim
+++ b/autoload/airline/util.vim
@@ -2,7 +2,6 @@
 " vim: et ts=2 sts=2 sw=2
 
 call airline#init#bootstrap()
-let s:spc = g:airline_symbols.space
 
 function! airline#util#wrap(text, minwidth)
   if a:minwidth > 0 && winwidth(0) < a:minwidth
@@ -12,18 +11,20 @@ function! airline#util#wrap(text, minwidth)
 endfunction
 
 function! airline#util#append(text, minwidth)
+  let l:spc = g:airline_symbols.pad_sep
   if a:minwidth > 0 && winwidth(0) < a:minwidth
     return ''
   endif
-  let prefix = s:spc == "\ua0" ? s:spc : s:spc.s:spc
-  return empty(a:text) ? '' : prefix.g:airline_left_alt_sep.s:spc.a:text
+  let prefix = l:spc == "\ua0" ? l:spc : l:spc.l:spc
+  return empty(a:text) ? '' : prefix.g:airline_left_alt_sep.l:spc.a:text
 endfunction
 
 function! airline#util#prepend(text, minwidth)
+  let l:spc = g:airline_symbols.pad_sep
   if a:minwidth > 0 && winwidth(0) < a:minwidth
     return ''
   endif
-  return empty(a:text) ? '' : a:text.s:spc.g:airline_right_alt_sep.s:spc
+  return empty(a:text) ? '' : a:text.l:spc.g:airline_right_alt_sep.l:spc
 endfunction
 
 if v:version >= 704

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -208,6 +208,24 @@ its contents. >
   let g:airline_symbols.linenr = '⭡'
 <
 
+White space and padding:
+
+Some white space variables exist to allow greater control of padding and
+white space.  If these are changed after airline is running you may need to
+:AirlineRefresh to see your changes
+
+Note: You must define the dictionary first before setting values. Also, it's a
+good idea to check whether if it exists as to avoid accidentally overwritting
+its contents. >
+
+  variable names                     usage
+  ----------------------------------------------------------------------------
+  let g:airline_symbols.space        normal space
+  let g:airline_symbols.pad          padding that can collapse
+  let g:airline_symbols.pad_section  padding at start and end of a section
+  let g:airline_symbols.pad_sep      padding around a separator
+
+
 For more intricate customizations, you can replace the predefined sections
 with the usual statusline syntax.
 

--- a/t/section.vim
+++ b/t/section.vim
@@ -66,6 +66,13 @@ describe 'section'
     Expect s == '%t%{airline#parts#sep_right()}asdf%{airline#parts#sep_right()}%{getcwd()}'
   end
 
+  it 'should return separators expected'
+    let s = airline#parts#sep_left()
+    Expect s == ' > '
+    let s = airline#parts#sep_right()
+    Expect s == ' < '
+  end
+
   it 'should empty out parts that do not pass their condition'
     call airline#parts#define_text('conditional', 'conditional')
     call airline#parts#define_condition('conditional', '0')

--- a/t/section.vim
+++ b/t/section.vim
@@ -57,13 +57,13 @@ describe 'section'
 
   it 'should force add separators for raw and missing keys'
     let s = airline#section#create_left(['asdf', 'raw'])
-    Expect s == 'asdf > raw'
+    Expect s == 'asdf%{airline#parts#sep_left()}raw'
     let s = airline#section#create_left(['asdf', 'aaaa', 'raw'])
-    Expect s == 'asdf > aaaa > raw'
+    Expect s == 'asdf%{airline#parts#sep_left()}aaaa%{airline#parts#sep_left()}raw'
     let s = airline#section#create_right(['raw', '%f'])
-    Expect s == 'raw < %f'
+    Expect s == 'raw%{airline#parts#sep_right()}%f'
     let s = airline#section#create_right(['%t', 'asdf', '%{getcwd()}'])
-    Expect s == '%t < asdf < %{getcwd()}'
+    Expect s == '%t%{airline#parts#sep_right()}asdf%{airline#parts#sep_right()}%{getcwd()}'
   end
 
   it 'should empty out parts that do not pass their condition'


### PR DESCRIPTION
I've been enjoying `vim-airline`

I created an extension  [vim-budget-airline](https://github.com/tobes/vim-budget-airline) to be more compact while still show most information in small screen widths, but looking like the default at wide screen widths..

**This pull request addressed the following issues:**

`vim-airline`

*  does not well support `g:airline_symbols.space` being changed on the fly after initialization.
*  `g:airline_symbols.space` is used in many different ways

**Changes:**

`g:airline_symbols.space` in core is fixed to respond to on the fly changes `:AirlineRefresh` is still needed for the change to take affect.  Most extensions cache `g:airline_symbols.space` this is **not** addressed in this patch.

This patch provides three new `g:airline_symbol` options

*  `pad`  -  padding that can collapse but is nice to have
*  `pad_section`  -  padding at start and end of a section
*  `pad_sep`  -  padding around a separator

They default to the value of  `g:airline_symbols.space` so no user configurations should be affected by this patch.

`g:airline_symbols.space`  remains and would be used where a space is required.

**Note:**

`airline#parts#sep_left()` and `airline#parts#sep_right()` are needed as the separators between raw elements are created and not dynamic (I suspect they may also be rarely used).  This patch uses these dynamic functions so they remain correct if the config is updated on the fly.  

My extension works but I have had to be quite invasive to get it that way.  This patch would simplify things and allow for the development of alternative extensions that seek similar effects.