### PR TITLE
Improved documentation on formatters

### DIFF
--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -489,7 +489,11 @@ exposed.
   endfunction
   let g:airline#extensions#tabline#formatter = 'foo'
 <
-  Note: the following variables are only used by the 'default' formatter.
+
+  Note: the following variables are only used by the 'default' formatter. 
+  When no disambiguation is needed, both 'unique_tail_improved' and 
+  'unique_tail' delegate formatting to 'default', so these variables also
+  control rendering of unique filenames when using these formatters.
 
     * configure whether buffer numbers should be shown. >
       let g:airline#extensions#tabline#buffer_nr_show = 0


### PR DESCRIPTION
This is my first pull request on GitHub *and* my first-attempt at editing a Vim documentation file, so I'm probably doing something wrong :-)

I've tried to improve a bit the documentation on how tabline filename formatters behave, and especially how `unique_tail*` delegate to `default` when they have nothing to disambiguate. I had to look around the code to understand this, and it seems I'm not the only having had that problem: #416.