### PR TITLE
Fix vim-capslock functionality after changes in CapsLockStatusline()

### DIFF
--- a/autoload/airline/extensions/capslock.vim
+++ b/autoload/airline/extensions/capslock.vim
@@ -5,7 +5,7 @@ if !exists('*CapsLockStatusline')
 endif
 
 function! airline#extensions#capslock#status()
-  return CapsLockStatusline() == '[caps]' ? 'CAPS' : ''
+  return tolower(CapsLockStatusline()) == '[caps]' ? 'CAPS' : ''
 endfunction
 
 function! airline#extensions#capslock#init(ext)


### PR DESCRIPTION
CapsLockStatusline() used to return '[caps]' when soft-capslock was on... and
now returns '[Caps]'.  As we're just using this to test for the lock, we
lower-case the return value in order to "normalize" the value across versions.

The change in behaviour can be seen at:

tpope/vim-capslock@3a0f0513730f03ebabc35ab18f6d771f1d979a3f