### PR TITLE
Sweep tabline of unlisted buffers on BufLeave

### DIFF
--- a/autoload/airline/extensions/tabline/autoshow.vim
+++ b/autoload/airline/extensions/tabline/autoshow.vim
@@ -34,7 +34,7 @@ function! airline#extensions#tabline#autoshow#on()
 
     " Invalidate cache.  This has to come after the BufUnload for
     " s:show_buffers, to invalidate the cache for BufEnter.
-    autocmd BufAdd,BufUnload * call airline#extensions#tabline#buflist#invalidate()
+    autocmd BufLeave,BufAdd,BufUnload * call airline#extensions#tabline#buflist#invalidate()
   augroup END
 endfunction
 


### PR DESCRIPTION
Possibly unnecessary. See #855

This simply unlets `s:current_buffer_list` in `tabline/buflist.vim`, forcing `tabline#buflist#list()` to remake the buffer list from scratch when next invoked. (By the way, `cur` in `buflist#list()` is declared/assigned but never used.) Perhaps it's better to remove unlisted stragglers in a more surgical fashion (like with `remove()`). Regardless, such a wholesale approach should probably be tested for bottlenecks, since leaving buffers occurs more or less constantly over a given session. This, of course, assumes adding `BufLeave` doesn't break anything outright.