### PR TITLE
Improve the wordcount plugin

### DIFF
--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -206,7 +206,7 @@ function! airline#extensions#load()
     call airline#extensions#whitespace#init(s:ext)
   endif
 
-  if get(g:, 'airline#extensions#wordcount#enabled', 1)
+  if get(g:, 'airline#extensions#wordcount#enabled', 0)
     call airline#extensions#wordcount#init(s:ext)
   endif
 

--- a/autoload/airline/extensions.vim
+++ b/autoload/airline/extensions.vim
@@ -206,7 +206,7 @@ function! airline#extensions#load()
     call airline#extensions#whitespace#init(s:ext)
   endif
 
-  if get(g:, 'airline#extensions#wordcount#enabled', 0)
+  if get(g:, 'airline#extensions#wordcount#enabled', 1)
     call airline#extensions#wordcount#init(s:ext)
   endif
 

--- a/autoload/airline/extensions/wordcount.vim
+++ b/autoload/airline/extensions/wordcount.vim
@@ -1,40 +1,36 @@
 " MIT License. Copyright (c) 2013-2015 Bailey Ling.
 " vim: et ts=2 sts=2 sw=2
 
+let s:spc = g:airline_symbols.space
+
 let s:filetypes = get(g:, 'airline#extensions#wordcount#filetypes', '\vhelp|markdown|rst|org')
+let s:format = get(g:, 'airline#extensions#wordcount#format', '%d'.s:spc.'words')
 
 " adapted from http://stackoverflow.com/questions/114431/fast-word-count-function-in-vim
-function! s:update()
-  if &ft !~ s:filetypes
-    unlet! b:airline_wordcount
-    return
-  endif
-
-  let old_status = v:statusmsg
-  let position = getpos(".")
+function! airline#extensions#wordcount#get_wordcount()
+  let l:old_status = v:statusmsg
+  let l:position = getpos(".")
   exe "silent normal! g\<c-g>"
-  let stat = v:statusmsg
-  call setpos('.', position)
-  let v:statusmsg = old_status
+  let l:stat = v:statusmsg
+  call setpos('.', l:position)
+  let v:statusmsg = l:old_status
 
-  let parts = split(stat)
-  if len(parts) > 11
-    let cnt = str2nr(split(stat)[11])
-    let spc = g:airline_symbols.space
-    let b:airline_wordcount = cnt . spc . 'words' . spc . g:airline_right_alt_sep . spc
-  else
-    unlet! b:airline_wordcount
+  let l:parts = split(l:stat)
+  let l:res = ''
+  if len(l:parts) > 11
+    let l:cnt = str2nr(split(stat)[11])
+    try
+      let l:res = printf(s:format, cnt).s:spc
+    catch /^Vim\%((\a\+)\)\=:E767/
+      " printf: wrong format
+      let l:res = ''
+    endtry
   endif
-endfunction
-
-function! airline#extensions#wordcount#apply(...)
-  if &ft =~ s:filetypes
-    call airline#extensions#prepend_to_section('z', '%{get(b:, "airline_wordcount", "")}')
-  endif
+  return l:res
 endfunction
 
 function! airline#extensions#wordcount#init(ext)
-  call a:ext.add_statusline_func('airline#extensions#wordcount#apply')
-  autocmd BufReadPost,CursorMoved,CursorMovedI * call s:update()
+  call airline#parts#define_function('wordcount', 'airline#extensions#wordcount#get_wordcount')
+  call airline#parts#define_condition('wordcount', "(&filetype =~ '" . s:filetypes . "')")
 endfunction
 

--- a/autoload/airline/init.vim
+++ b/autoload/airline/init.vim
@@ -81,7 +81,7 @@ function! airline#init#bootstrap()
   call airline#parts#define_raw('file', '%f%m')
   call airline#parts#define_raw('linenr', '%{g:airline_symbols.linenr}%#__accent_bold#%4l%#__restore__#')
   call airline#parts#define_function('ffenc', 'airline#parts#ffenc')
-  call airline#parts#define_empty(['hunks', 'branch', 'tagbar', 'syntastic', 'eclim', 'whitespace','windowswap'])
+  call airline#parts#define_empty(['hunks', 'branch', 'tagbar', 'syntastic', 'eclim', 'whitespace','windowswap','wordcount'])
   call airline#parts#define_text('capslock', '')
 
   unlet g:airline#init#bootstrapping
@@ -108,7 +108,7 @@ function! airline#init#sections()
     let g:airline_section_y = airline#section#create_right(['ffenc'])
   endif
   if !exists('g:airline_section_z')
-    let g:airline_section_z = airline#section#create(['windowswap', '%3p%%'.spc, 'linenr', ':%3v '])
+    let g:airline_section_z = airline#section#create(['wordcount','windowswap', '%3p%%'.spc, 'linenr', ':%3v '])
   endif
   if !exists('g:airline_section_warning')
     let g:airline_section_warning = airline#section#create(['syntastic', 'eclim', 'whitespace'])

--- a/doc/airline.txt
+++ b/doc/airline.txt
@@ -409,6 +409,10 @@ eclim <https://eclim.org>
   " the default value matches filetypes typically used for documentation
   " such as markdown and help files.
   let g:airline#extensions#wordcount#filetypes = ...
+* format for the status
+  >
+  " Use '%d' in place of the number of words
+  let g:airline#extensions#wordcount#format = '%dW'
 <
 -------------------------------------                   *airline-whitespace*
 * enable/disable detection of whitespace errors. >


### PR DESCRIPTION
Solve several issues with the wordcount plugin, and resolve all the
problems raised in #864
- Add a way to format the status message
- Keep the code modular and clean, using Airline's API
- Add new documentation to support the new format feature
- Correct the default behaviour. Keep it disabled by default (by the
  documentation), but allow enabling the extension to add it to the
  default statusline sections

I opened issue #864, this refactors the extension to be more like the others.