### PR TITLE
Change normal command to normal! command

### DIFF
--- a/autoload/airline/extensions/wordcount.vim
+++ b/autoload/airline/extensions/wordcount.vim
@@ -12,7 +12,7 @@ function! s:update()
 
   let old_status = v:statusmsg
   let position = getpos(".")
-  exe "silent normal g\<c-g>"
+  exe "silent normal! g\<c-g>"
   let stat = v:statusmsg
   call setpos('.', position)
   let v:statusmsg = old_status


### PR DESCRIPTION
The wordcount extension should use `normal!` (with a bang) instead of just `normal` to get the status message.

I have `g<C-g>` mapped to copy the buffer's directory name and noticed my registers getting overwritten when I changed windows and found this as a result.